### PR TITLE
Fixed Python3 pickle bug

### DIFF
--- a/dump_to_csv.py
+++ b/dump_to_csv.py
@@ -12,7 +12,9 @@ def read(data_dir):
     with open(output_filename, 'w') as w:
         for filename in iglob(data_dir + '/*.pkl'):
             with open(filename, 'rb') as f:
-                data = pickle.load(f)
+                u = pickle._Unpickler(f)
+                u.encoding = 'latin1'
+                data = u.load()
                 for datum in data:
 
                     ts = datum['ts']


### PR DESCRIPTION
I fixed the bug appearing when launching dump_to_csv.py with python3, it seemed something related to pickle,
When launching ```python3 dump_to_csv.py data/```, 
the following trace was given in output:
```
Traceback (most recent call last):
File "dump_to_csv.py", line 38, in
read(sys.argv[1])
File "dump_to_csv.py", line 15, in read
data = pickle.load(f)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 8: ordinal not in range(128)
```
After my simple fix it works without any problems with python3, I would be glad if you can pull these changes into your master branch if possible.